### PR TITLE
fix(dependabot): [MEDO-469] add 7-day cooldown block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       composer-minor-patch:
@@ -21,6 +23,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns: ["*"]


### PR DESCRIPTION
fix(dependabot): [MEDO-469] add 7-day cooldown block

Newly published packages can be malicious or unstable. Adds a cooldown
block (default-days: 7) to each package-ecosystem entry so newly released
versions wait 7 days before Dependabot proposes them. cooldown applies to
version updates only, so security updates are still proposed immediately.
This clears the blocking semgrep rule dependabot-missing-cooldown that was
failing CI (semgrep scan --config auto --error).

Refs: MEDO-469